### PR TITLE
Tiny type declaration fix

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -57,7 +57,7 @@ export interface DialogNotifyOptions extends DialogActionable {
 }
 
 export interface DialogConfirmOptions extends DialogActionable {
-  icon?: string
+  icon?: string | boolean
   persistent?: boolean
   showClose?: boolean
   scrollable?: Boolean,


### PR DESCRIPTION
The `icon` option allows a string *or* a boolean `false`. Fixed type definition to match.