### PR TITLE
fix titleClass on prompt, add style options for TextField 

### DIFF
--- a/src/components/DialogCard.vue
+++ b/src/components/DialogCard.vue
@@ -4,16 +4,14 @@
     :class="{'v-inner-scroll': innerScroll }"
   >
     <slot name="title">
-      <v-card-title v-if="title">
-        <div
-          :class="titleClass"
-          v-text="title"
-        />
+      <v-card-title v-if="title" class="mb-2" :class="titleClass">
+        <div v-text="title" />
       </v-card-title>
     </slot>
     <v-card-text>
       <slot />
     </v-card-text>
+    <v-divider />
     <v-card-actions v-if="actions">
       <v-spacer />
       <DialogActions
@@ -48,7 +46,8 @@ export default {
     innerScroll: Boolean,
     titleClass: String,
     actions: [Array, Object, Function],
-    handle: Function
+    handle: Function,
+    titleClass: String
   },
   methods: {
     trigger (name) {

--- a/src/components/Prompt.vue
+++ b/src/components/Prompt.vue
@@ -37,7 +37,7 @@ export default {
   layout: 'default',
   mixins: [Confirmable],
   props: {
-    value: String
+    value: String,
     titleClass: String,
     textField: {
       type: Object,

--- a/src/components/Prompt.vue
+++ b/src/components/Prompt.vue
@@ -4,6 +4,7 @@
       :title="title"
       :actions="actions"
       :handle="handleClick"
+      :titleClass="titleClass"
       ref="card"
     >
       <v-text-field
@@ -12,6 +13,11 @@
         v-model="editedValue"
         :label="text"
         @keypress.enter="$emit('submit', editedValue)"
+        :singleLine="textField.singleLine"
+        :rounded="textField.rounded"
+        :solo="textField.solo"
+        :filled="textField.filled"
+        :outlined="textField.outlined"
       />
     </DialogCard>
   </div>
@@ -32,6 +38,18 @@ export default {
   mixins: [Confirmable],
   props: {
     value: String
+    titleClass: String,
+    textField: {
+      type: Object,
+      default: () => ({
+        singleLine: false,
+        rounded: false,
+        solo: false,
+        filled: false,
+        outlined: false,
+        autofocus: true
+      })
+    }
   },
   data () {
     return {
@@ -40,7 +58,7 @@ export default {
   },
   mounted () {
     setTimeout(() => {
-      this.$refs.input.focus()
+      if(this.textField.autofocus) this.$refs.input.focus()
     }, 100)
   },
   methods: {


### PR DESCRIPTION
Hello

fix titleClass on prompt, add style options for TextField 

Example to use
```
      this.$dialog
        .prompt({
          titleClass: 'v-sheet v-sheet--tile theme--dark v-toolbar v-toolbar--dense purple',
          textField: {
            outlined: true
          },
          text: 'Please enter',
        })
```