### PR TITLE
Add 'NuxtAppOptions' interface on index.d.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ Module automatically add to dialog nuxt context data, such as router, route, i18
 }
 ```
 
+### If you using Typescript + Nuxt.js
+Add `vuetify-dialog/types` to the `compilerOptions.types` section of your project's `tsconfig.json` file:
+```json
+{
+  "compilerOptions": {
+    "types": [
+      "vuetify-dialog/types"
+    ]
+  }
+}
+```
+
 
 ### Simple confirm dialog
 ```js

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,7 +28,7 @@ export interface DialogAction {
 export type DialogActions = Record<string, DialogAction>
 
 interface DialogActionable {
-  actions?: Array<string|DialogAction> | Array<DialogAction> | DialogActions | Record<string, string> 
+  actions?: Array<string|DialogAction> | Array<DialogAction> | DialogActions | Record<string, string>
   handler? (action: any): void | any
 }
 
@@ -141,6 +141,10 @@ declare module '@nuxt/types' {
   // }
   interface Context {
     $dialog: VuetifyDialog;
+  }
+  
+  interface NuxtAppOptions {
+    $dialog: VuetifyDialog
   }
 }
 // declare module 'vue/types/options' {


### PR DESCRIPTION
Add 'NuxtAppOptions' interface on index.d.ts and update README.md for using typescript + nuxt

[related issue](https://github.com/yariksav/vuetify-dialog/issues/136)
